### PR TITLE
fix copyright info dynamically

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const form = document.getElementById("form");
 const pw1 = document.getElementById("password")
 const pw2 = document.getElementById("confirmPassword");
 const errorMessage = document.getElementById("pwCheck");
+const copyrightYear =  document.querySelector(".footer--year")
 let isPasswordMatched = null;
 
 function comparePassword(e) {
@@ -31,4 +32,7 @@ function checkForm(e) {
 pw1.addEventListener('keyup', comparePassword);
 pw2.addEventListener('keyup', comparePassword);
 form.addEventListener('submit', checkForm);
+
+/* footer */
+copyrightYear = new Date().getFullYear()
 


### PR DESCRIPTION
Another issue to be considered about usingdocument.write (and not only in a script injection case): if the DOM tree has already been built, the use of document.write will force the browser to build it again… A pity for the performance! (document.write writes to the document stream, calling document.write on a closed – loaded – document will reset the current document.)